### PR TITLE
Concurrent read/write iteration and unsafe text/template use

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ semgrep --test --test-ignore-todo --metrics=off --config ./go/iterate-over-empty
 
 | ID | Impact | Confidence | Description |
 | -- | :----: | :--------: | ----------- |
+| [concurrent-writes-iteration](go/concurrent-writes-iteration.yaml) | 🟧 | 🌗 | Concurrent writes and iteration to a map will result in panic |
 | [creds-from-jwtconfig](go/creds-from-jwtconfig.yaml) | 🟧 | 🌘 | Using JWT configuration from JSON rather than using service accounts could lead to exposed credentials in code and other insecure key management practices |
 | [defer-in-loop](go/defer-in-loop.yaml) | 🟩 | 🌗 | Resource leak due improper use of `defer` |
-| [gcs-path-traversal](go/gcs-path-traversal.yaml) | 🟧 | 🌗 | An HTTP redirect was found to be crafted from user-input leading to an open redirect vulnerability |
+| [gcs-path-traversal](go/gcs-path-traversal.yaml) | 🟧 | 🌗 | A GCS file path was found to be crafted from user-input which could lead to path traversal within a bucket |
 | [insecure-dir-creation](go/insecure-dir-creation.yaml) | 🟧 | 🌘 | Insecure handling of file and directory writes |
 | [missing-close-on-file](go/missing-close-on-file.yaml) | 🟩 | 🌗 | Handling of open file descriptors |
 | [missing-defer-http](go/missing-defer-http.yaml) | 🟩 | 🌗 | Handling of HTTP response bodies |
+| [text-template-unsafe-html](go/text-template-unsafe-html.yaml) | 🟥 | 🌘 |  |
 
 
 ### optimizations
 
 | ID | Impact | Confidence | Description |
 | -- | :----: | :--------: | ----------- |
-| [math-random-used](optimizations/math-random-used.yaml) | 🟧 | 🌗 | Finds likely cases where `math/rand` may be used insecurely. For the optimization, we exclude functions like `Shuffle` which are rarely used cryptographically |
+| [math-random-used](optimizations/math-random-used.yaml) | 🟧 | 🌗 | Finds likely cases where `math/rand` may be used insecurely. For the optimization, we exclude functions like `Shuffle` which are realy used cryptographically

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ semgrep --test --test-ignore-todo --metrics=off --config ./go/iterate-over-empty
 | [insecure-dir-creation](go/insecure-dir-creation.yaml) | 🟧 | 🌘 | Insecure handling of file and directory writes |
 | [missing-close-on-file](go/missing-close-on-file.yaml) | 🟩 | 🌗 | Handling of open file descriptors |
 | [missing-defer-http](go/missing-defer-http.yaml) | 🟩 | 🌗 | Handling of HTTP response bodies |
-| [text-template-unsafe-html](go/text-template-unsafe-html.yaml) | 🟥 | 🌘 |  |
+| [text-template-unsafe-html](go/text-template-unsafe-html.yaml) | 🟥 | 🌘 | Detected unsafe rendering of HTML content using text/template |
 
 
 ### optimizations

--- a/go/concurrent-writes-iteration.go
+++ b/go/concurrent-writes-iteration.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Positive test case 3: Map passed as parameter
+func updateMap(m map[string]int) {
+	m["updated"] = 100
+}
+
+// Positive test case 4: Using errgroup for concurrent map operations
+func positiveCase1() {
+	var g errgroup.Group
+
+	store := make(map[string]string)
+	store["item1"] = "value1"
+	store["item2"] = "value2"
+
+	for key, val := range store {
+		k, v := key, val
+		g.Go(func() error {
+			// ruleid: concurrent-writes-iteration
+			store[k] = v + "_modified"
+			return nil
+		})
+	}
+
+	// Wait for all goroutines to complete
+	g.Wait()
+}
+
+// Positive test case 5: Using errgroup with a more complex structure
+type DataStore struct {
+	Items map[string]Item
+}
+
+type Item struct {
+	Value string
+}
+
+// using sync.Map for concurrent safety
+func negativeCase1() {
+	var safeMap sync.Map
+
+	go func() {
+		// ok: concurrent-writes-iteration
+		safeMap.Store("key", 1)
+	}()
+
+	safeMap.Range(func(key, value interface{}) bool {
+		fmt.Println(key, value)
+		return true
+	})
+}
+
+// Iterating over a copy for reads
+func negativeCase2() {
+	var g errgroup.Group
+	store := make(map[string]string)
+	store["item1"] = "value1"
+	store["item2"] = "value2"
+
+	// Safe copy of keys to avoid iteration during modification
+	keys := make([]string, 0, len(store))
+	for k := range store {
+		keys = append(keys, k)
+	}
+
+	for _, key := range keys {
+		k := key
+		g.Go(func() error {
+			// ok: concurrent-writes-iteration
+			store[k] = store[k] + "_modified"
+			return nil
+		})
+	}
+
+	g.Wait()
+}
+
+// Map passed to goroutine directly (pattern excluded by rule)
+func negativeCase3() {
+	myMap := make(map[string]int)
+
+	// ok: concurrent-writes-iteration
+	go func(m map[string]int) {
+		m["key"] = 1
+	}(myMap)
+
+	for k, v := range myMap {
+		fmt.Println(k, v)
+	}
+}
+
+// Sequential operations (no concurrency)
+func negativeCase4() {
+	myMap := make(map[string]int)
+	myMap["key1"] = 1
+
+	// sequential, not concurrent
+	for k, v := range myMap {
+		// ok: concurrent-writes-iteration
+		fmt.Println(k, v)
+	}
+
+	myMap["key2"] = 2
+}
+
+func main() {
+	positiveCase1()
+
+	negativeCase1()
+	negativeCase2()
+	negativeCase3()
+	negativeCase4()
+}

--- a/go/concurrent-writes-iteration.go
+++ b/go/concurrent-writes-iteration.go
@@ -7,12 +7,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Positive test case 3: Map passed as parameter
+// Map passed as parameter
 func updateMap(m map[string]int) {
 	m["updated"] = 100
 }
 
-// Positive test case 4: Using errgroup for concurrent map operations
+// Using errgroup for concurrent map operations
 func positiveCase1() {
 	var g errgroup.Group
 
@@ -33,7 +33,6 @@ func positiveCase1() {
 	g.Wait()
 }
 
-// Positive test case 5: Using errgroup with a more complex structure
 type DataStore struct {
 	Items map[string]Item
 }

--- a/go/concurrent-writes-iteration.yaml
+++ b/go/concurrent-writes-iteration.yaml
@@ -1,0 +1,56 @@
+rules:
+  - id: concurrent-writes-iteration
+    message: Concurrent `$MAP` iteration and write
+    languages:
+      - go
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-362: Concurrent Execution using Shared Resource with Improper
+        Synchronization ('Race Condition')"
+      subcategory:
+        - vuln
+      confidence: MEDIUM
+      likelihood: HIGH
+      impact: MEDIUM
+      technology:
+        - --no-technology--
+      description: Concurrent writes and iteration to a map will result in panic
+      references:
+        - https://go.dev/blog/maps#concurrency
+    patterns:
+      - pattern-either:
+          - pattern: $MAP[...] = $VALUE
+          - pattern: $MAP.$_[...] = $VALUE
+          - pattern: $UPDATER(..., $MAP, ...)
+          - pattern: $UPDATER(..., $MAP[...], ...)
+      - pattern-either:
+          - pattern-inside: |-
+              $G.Go(func(...) {
+                    ...
+              })
+          - pattern-inside: |-
+              go func(...) {
+                    ...
+              }(...)
+      - pattern-either:
+          - pattern-inside: |
+              for $K, $V := range $MAP  {
+                ...
+              }
+          - pattern-inside: |
+              for $K, $V := range $MAP.$_  {
+                ...
+              }
+      - pattern-either:
+          - pattern-inside: |
+              func $F (..., $MAP $TYPE, ...) {
+                  ...
+              }
+          - pattern-inside: |
+              $MAP = make(map[$KTYPE]$VTYPE)
+              ...
+      - pattern-not-inside: |
+          go func(..., $CPY $_, ...) {
+              ...
+          }(..., $MAP, ...)

--- a/go/text-template-unsafe-html.go
+++ b/go/text-template-unsafe-html.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"net/http"
+	"text/template"
+)
+
+var embedded embed.FS
+
+// Top-level const with raw HTML
+const (
+	notificationTemplate = `<h1>New CI failures for {{.Project}}</h1>`
+)
+
+func directXSS(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	// ruleid: text-template-unsafe-html
+	tmpl, _ := template.New("greet").Parse("<h1>Hello " + name + "!</h1>")
+	tmpl.Execute(w, nil)
+}
+
+func htmlAttrXSS(w http.ResponseWriter, r *http.Request) {
+	color := r.FormValue("color")
+	// ruleid: text-template-unsafe-html
+	tmpl, _ := template.New("color").Parse(`<div style="color:` + color + `">Colored text</div>`)
+	tmpl.Execute(w, nil)
+}
+
+func fmtSprintfXSS(w http.ResponseWriter, r *http.Request) {
+	msg := r.FormValue("msg")
+	// ruleid: text-template-unsafe-html
+	tmpl := template.Must(template.New("msg").Parse(fmt.Sprintf("<p>%s</p>", msg)))
+	tmpl.Execute(w, nil)
+}
+
+func constOutsideXSS(w http.ResponseWriter, r *http.Request) {
+	project := r.URL.Query().Get("project")
+	// ruleid: text-template-unsafe-html
+	t := template.Must(template.New("notify").Parse(notificationTemplate))
+	t.Execute(w, map[string]string{"Project": project})
+}
+
+func fileIncludeXSS(w http.ResponseWriter, r *http.Request) {
+	page := r.URL.Query().Get("page")
+	// ruleid: text-template-unsafe-html
+	template.ParseFS(embedded, page+".html")
+}
+
+func nestedXSS(w http.ResponseWriter, r *http.Request) {
+	comment := r.FormValue("comment")
+	// ruleid: text-template-unsafe-html
+	template.New("c").Funcs(template.FuncMap{}).
+		Parse("<span>" + comment + "</span>")
+}
+
+func safeFileExt(w http.ResponseWriter, r *http.Request) {
+	page := r.URL.Query().Get("page")
+	// ok: text-template-unsafe-html
+	template.ParseFS(embedded, page+".tmpl")
+}
+
+func main() {
+	http.HandleFunc("/direct", directXSS)
+	http.HandleFunc("/attr", htmlAttrXSS)
+	http.HandleFunc("/sprintf", fmtSprintfXSS)
+	http.HandleFunc("/const", constOutsideXSS)
+	http.HandleFunc("/file", fileIncludeXSS)
+	http.HandleFunc("/nested", nestedXSS)
+	http.HandleFunc("/safe-ext", safeFileExt)
+	http.ListenAndServe(":8080", nil)
+}

--- a/go/text-template-unsafe-html.yaml
+++ b/go/text-template-unsafe-html.yaml
@@ -3,11 +3,11 @@ rules:
     options:
       symbolic_propagation: true
     message: >
-      Detected unsafe rendering of HTML content using text/template—raw HTML or
-      user-supplied content is passed directly to text/template methods,  which
+      Detected unsafe rendering of HTML content using text/template,  which
       do not auto-escape HTML.  This can lead to Cross-Site Scripting (XSS).
       Switch to html/template or ensure proper escaping.
     severity: WARNING
+    description: Detected unsafe rendering of HTML content using text/template
     metadata:
       category: security
       technology:

--- a/go/text-template-unsafe-html.yaml
+++ b/go/text-template-unsafe-html.yaml
@@ -1,0 +1,65 @@
+rules:
+  - id: text-template-unsafe-html
+    options:
+      symbolic_propagation: true
+    message: >
+      Detected unsafe rendering of HTML content using text/template—raw HTML or
+      user-supplied content is passed directly to text/template methods,  which
+      do not auto-escape HTML.  This can lead to Cross-Site Scripting (XSS).
+      Switch to html/template or ensure proper escaping.
+    severity: WARNING
+    metadata:
+      category: security
+      technology:
+        - go
+      owasp:
+        - A07:2021 - Cross-Site Scripting (XSS)
+        - A03:2021 - Injection
+      cwe:
+        - "CWE-79: Improper Neutralization of Input During Web Page Generation
+          ('Cross-site Scripting')"
+      references:
+        - https://pkg.go.dev/text/template
+        - https://pkg.go.dev/html/template
+        - https://www.veracode.com/blog/secure-development/use-golang-these-mistakes-could-compromise-your-apps-security
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      vulnerability_class:
+        - Cross-Site Scripting (XSS)
+    patterns:
+      - pattern-inside: |
+          import "$IMPORT"
+          ...
+      - metavariable-regex:
+          metavariable: $IMPORT
+          regex: ^(text/template)$
+      - pattern-either:
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      $TEMPLATE.$FUNC($HTMLSTR)
+                  - pattern: |
+                      $TEMPLATE.$FUNC(fmt.Sprintf("$HTMLSTR", $_))
+                  - pattern: |
+                      $TEMPLATE.$FUNC($HTMLSTR + $_ + $_)
+                  - pattern: |
+                      $TEMPLATE.$FUNC($_ + $_ + $HTMLSTR)
+                  - pattern: |
+                      $TEMPLATE.$_(...).$_(...).$FUNC($HTMLSTR)
+              - metavariable-comparison:
+                  comparison: re.match('.*<[^>]+>.*', $HTMLSTR)
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      $TEMPLATE.$FUNC(..., $ARGS, ...)
+                  - pattern: |
+                      $TEMPLATE.$FUNC(..., $_ + "$ARGS", ...)
+              - metavariable-regex:
+                  metavariable: $ARGS
+                  regex: .*\.html$
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: ^(ParseFiles|ParseFS|Parse|ExecuteTemplate)$
+    languages:
+      - go


### PR DESCRIPTION
Adds two new rules


| ID | Impact | Confidence | Description |
| -- | :----: | :--------: | ----------- |
| [concurrent-writes-iteration](go/concurrent-writes-iteration.yaml) | 🟧 | 🌗 | Concurrent writes and iteration to a map will result in panic |
| [text-template-unsafe-html](go/text-template-unsafe-html.yaml) | 🟥 | 🌘 |  Detected unsafe rendering of HTML content using text/template |
